### PR TITLE
agent: use padding in signatures, change agent ID encoding to base36

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -73,6 +73,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "base36"
+version = "0.0.0"
+source = "git+https://github.com/transumption-unstable/base36?rev=4e6981e13ec5f3748dfe9b8870aa4e8ed749096d#4e6981e13ec5f3748dfe9b8870aa4e8ed749096d"
+dependencies = [
+ "base-x 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +730,7 @@ dependencies = [
 name = "holo-router-agent"
 version = "0.0.0"
 dependencies = [
+ "base36 0.0.0 (git+https://github.com/transumption-unstable/base36?rev=4e6981e13ec5f3748dfe9b8870aa4e8ed749096d)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3188,6 +3203,8 @@ dependencies = [
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
+"checksum base-x 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
+"checksum base36 0.0.0 (git+https://github.com/transumption-unstable/base36?rev=4e6981e13ec5f3748dfe9b8870aa4e8ed749096d)" = "<none>"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -11,6 +11,10 @@ reqwest = "0.9.11"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 
+[dependencies.base36]
+git = "https://github.com/transumption-unstable/base36"
+rev = "4e6981e13ec5f3748dfe9b8870aa4e8ed749096d"
+
 [dependencies.holochain_conductor_api]
 git = "https://github.com/holochain/holochain-rust"
 rev = "0d5f7634b9089477d50348855b1ffcf7f2f0dce5"


### PR DESCRIPTION
This switches HCID encoding in https://<agent_id>.holohost.net to Base36 in order to fit into TLS CN field so that we can get TLS certs.